### PR TITLE
Pass the HTTP status code to the parent class

### DIFF
--- a/src/Component/HttpFoundation/Response/RawJsonResponse.php
+++ b/src/Component/HttpFoundation/Response/RawJsonResponse.php
@@ -21,10 +21,12 @@ class RawJsonResponse extends JsonResponse
      *
      * @param string  $data    The raw JSON data
      * @param integer $status  The status code (defaults to 200)
+     * @param array   $headers An array of response headers
      */
-    public function __construct($data = null, $status = 200)
+    public function __construct($data = null, $status = 200, array $headers = array())
     {
-        $this->headers = new ResponseHeaderBag([]);
+        parent::__construct('', $status, $headers);
+
         $this->setData($data);
     }
 

--- a/src/Component/HttpFoundation/Tests/Response/RawJsonResponseTest.php
+++ b/src/Component/HttpFoundation/Tests/Response/RawJsonResponseTest.php
@@ -18,6 +18,19 @@ class RawJsonResponseTest extends \PHPUnit_Framework_TestCase
     public function testConstructor($data)
     {
         $response = new RawJsonResponse($data);
+
+        $this->assertEquals(RawJsonResponse::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals($data, $response->getContent());
+    }
+
+    /**
+     * @dataProvider getRawJsonData
+     */
+    public function testConstructorWithStatusCode($data)
+    {
+        $response = new RawJsonResponse($data, RawJsonResponse::HTTP_FORBIDDEN);
+
+        $this->assertEquals(RawJsonResponse::HTTP_FORBIDDEN, $response->getStatusCode());
         $this->assertEquals($data, $response->getContent());
     }
 


### PR DESCRIPTION
At the moment, no default HTTP status code is set because the parent constructor isn't called, this change defaults the status code to 200 unless specified otherwise.
